### PR TITLE
[FEATURE] Basic framework for generating paginations

### DIFF
--- a/docs/examples/page-one.md
+++ b/docs/examples/page-one.md
@@ -1,5 +1,8 @@
 ---
+id: page-one
 title: Page One
+prev: getting-started
+next: page-two
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Virtutibus igitur rectissime mihi videris et ad consuetudinem nostrae orationis vitia posuisse contraria. <i>Videsne quam sit magna dissensio?</i> Duo Reges: `construct() {}` interrete. <a href="http://loripsum.net/" target="_blank">Primum quid tu dicis breve?</a> <a href="http://loripsum.net/" target="_blank">Quis istum dolorem timet?</a> Torquatus, is qui consul cum Cn. Naturales divitias dixit parabiles esse, quod parvo esset natura contenta.

--- a/docs/examples/page-three.md
+++ b/docs/examples/page-three.md
@@ -1,6 +1,8 @@
 ---
+id: page-three
 permalink: /examples/page-with-custom-url
 title: With Custom URL
+prev: page-two
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cur tantas regiones barbarorum pedibus obiit, tot maria transmisit? Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio.

--- a/docs/examples/page-two.md
+++ b/docs/examples/page-two.md
@@ -9,12 +9,16 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ita ceterorum sententii
 
 _Quam ob rem tandem, inquit, non satisfacit?_ <a href="http://loripsum.net/" target="_blank">Inde igitur, inquit, ordiendum est.</a> Si mala non sunt, iacet omnis ratio Peripateticorum. <a href="http://loripsum.net/" target="_blank">Tibi hoc incredibile, quod beatissimum.</a> Ergo infelix una molestia, fellx rursus, cum is ipse anulus in praecordiis piscis inventus est? Tum, Quintus et Pomponius cum idem se velle dixissent, Piso exorsus est. Non pugnem cum homine, cur tantum habeat in natura boni; **Satis est ad hoc responsum.** Qui autem de summo bono dissentit de tota philosophiae ratione dissentit.
 
-```js
-import theme from '../styles/theme';
+```tsx
+interface Props {
+  className?: string;
+}
 
-const getEmSize = (size: number) => size / theme.dimensions.fontSize.regular;
+const ExampleComponent: React.SFC<Props> = ({ className, children }) => (
+  <div className={className}>{children}</div>
+);
 
-export default getEmSize;
+export default MarkdownContent;
 ```
 
 <mark>Quamquam haec quidem praeposita recte et reiecta dicere licebit.</mark> Cum autem venissemus in Academiae non sine causa nobilitata spatia, solitudo erat ea, quam volueramus. Itaque rursus eadem ratione, qua sum paulo ante usus, haerebitis. Transfer idem ad modestiam vel temperantiam, quae est moderatio cupiditatum rationi oboediens. Ad quorum et cognitionem et usum iam corroborati natura ipsa praeeunte deducimur. Atque haec coniunctio confusioque virtutum tamen a philosophis ratione quadam distinguitur.

--- a/docs/examples/page-two.md
+++ b/docs/examples/page-two.md
@@ -1,5 +1,8 @@
 ---
+id: page-two
 title: Page Two
+prev: page-one
+next: page-three
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ita ceterorum sententiis semotis relinquitur non mihi cum Torquato, sed virtuti cum voluptate certatio. Ergo adhuc, quantum equidem intellego, causa non videtur fuisse mutandi nominis. Hanc quoque iucunditatem, si vis, transfer in animum; Homines optimi non intellegunt totam rationem everti, si ita res se habeat. Duo Reges: constructio interrete. Quis `const temp: string;` enim redargueret? Ergo infelix una molestia, fellx rursus, cum is ipse anulus in praecordiis piscis inventus est? Quantum Aristoxeni ingenium consumptum videmus in musicis? Neminem videbis ita laudatum, ut artifex `serve` callidus comparandarum voluptatum diceretur. Nunc omni virtuti vitium contrario nomine opponitur.

--- a/docs/overview/about.md
+++ b/docs/overview/about.md
@@ -1,5 +1,7 @@
 ---
+id: about
 title: About
+next: getting-started
 ---
 
 Welcome to Grundgesetz. It's a skeleton for generating accessible documentation pages built on top of [Gatsby](https://www.gatsbyjs.org). It creates static pages from your Markdown documentation files, all prettily formatted with a easy-to-use layout.

--- a/docs/overview/getting-started.md
+++ b/docs/overview/getting-started.md
@@ -1,5 +1,8 @@
 ---
+id: getting-started
 title: Getting Started
+prev: about
+next: page-one
 ---
 
 Install this starter (assuming you have `gatsby-cli` installed) by running the following command:

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -1,7 +1,6 @@
 [
   {
-    "id": "overview",
-    "category": "Overview",
+    "title": "Overview",
     "items": [
       {
         "id": "about",
@@ -16,8 +15,7 @@
     ]
   },
   {
-    "id": "examples",
-    "category": "Examples",
+    "title": "Examples",
     "items": [
       {
         "id": "page-one",
@@ -25,12 +23,12 @@
         "title": "Page One"
       },
       {
-        "id": "page-one",
+        "id": "page-two",
         "slug": "/examples/page-two/",
         "title": "Page Two"
       },
       {
-        "id": "page-one",
+        "id": "page-three",
         "slug": "/examples/page-with-custom-url/",
         "title": "With Custom URL"
       }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -54,6 +54,7 @@ module.exports = {
       }
     },
     'gatsby-plugin-styled-components',
+    'gatsby-plugin-resolve-src',
     'gatsby-plugin-typescript',
     'gatsby-plugin-react-next',
     'gatsby-plugin-sharp',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,9 +1,9 @@
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
 exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
-  const { createNodeField } = boundActionCreators
+  const { createNodeField } = boundActionCreators;
 
   // Sometimes, optional fields tend to get not picked up by the GraphQL
   // interpreter if not a single content uses it. Therefore, we're putting them
@@ -12,13 +12,13 @@ exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
 
   switch (node.internal.type) {
     case 'MarkdownRemark': {
-      const { permalink, layout } = node.frontmatter
-      const { relativePath } = getNode(node.parent)
+      const { permalink, layout } = node.frontmatter;
+      const { relativePath } = getNode(node.parent);
 
-      let slug = permalink
+      let slug = permalink;
 
       if (!slug) {
-        slug = `/${relativePath.replace('.md', '')}/`
+        slug = `/${relativePath.replace('.md', '')}/`;
       }
 
       // Used to generate URL to view this content.
@@ -26,20 +26,20 @@ exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
         node,
         name: 'slug',
         value: slug || ''
-      })
+      });
 
       // Used to determine a page layout.
       createNodeField({
         node,
         name: 'layout',
-        value: layout || '',
-      })
+        value: layout || ''
+      });
     }
   }
-}
+};
 
 exports.createPages = async ({ graphql, boundActionCreators }) => {
-  const { createPage } = boundActionCreators
+  const { createPage } = boundActionCreators;
 
   const allMarkdown = await graphql(`
     {
@@ -54,15 +54,15 @@ exports.createPages = async ({ graphql, boundActionCreators }) => {
         }
       }
     }
-  `)
+  `);
 
   if (allMarkdown.errors) {
-    console.error(allMarkdown.errors)
-    throw new Error(allMarkdown.errors)
+    console.error(allMarkdown.errors);
+    throw new Error(allMarkdown.errors);
   }
 
   allMarkdown.data.allMarkdownRemark.edges.forEach(({ node }) => {
-    const { slug, layout } = node.fields
+    const { slug, layout } = node.fields;
 
     createPage({
       path: slug,
@@ -80,6 +80,6 @@ exports.createPages = async ({ graphql, boundActionCreators }) => {
         // Data passed to context is available in page queries as GraphQL variables.
         slug
       }
-    })
-  })
-}
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gatsby-plugin-canonical-urls": "^1.0.18",
     "gatsby-plugin-react-helmet": "^2.0.11",
     "gatsby-plugin-react-next": "^1.0.11",
+    "gatsby-plugin-resolve-src": "^1.1.3",
     "gatsby-plugin-sharp": "^1.6.44",
     "gatsby-plugin-styled-components": "^2.0.11",
     "gatsby-plugin-typescript": "^1.4.20",

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import styled from '../utils/styled';
+import styled from 'utils/styled';
 
-import { widths } from '../styles/variables';
-import { getEmSize } from '../styles/mixins';
+import { widths } from 'styles/variables';
+import { getEmSize } from 'styles/mixins';
 
 const StyledContainer = styled('div')`
   position: relative;

--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -1,4 +1,4 @@
-import styled from '../utils/styled';
+import styled from 'utils/styled';
 
 const DocsHeader = styled('header')`
   margin-bottom: 1rem;

--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -1,0 +1,15 @@
+import styled from '../utils/styled';
+
+const DocsHeader = styled('header')`
+  margin-bottom: 1rem;
+
+  h1 {
+    margin: 0;
+    font-weight: 600;
+    font-size: ${props => props.theme.dimensions.headingSizes.h1};
+    color: ${props => props.theme.colors.ink};
+    line-height: ${props => props.theme.dimensions.lineHeight.heading};
+  }
+`;
+
+export default DocsHeader;

--- a/src/components/DocsWrapper.tsx
+++ b/src/components/DocsWrapper.tsx
@@ -1,6 +1,6 @@
 import styled from '../utils/styled';
 
-const DocsWrapper = styled('div')`
+const DocsWrapper = styled('article')`
   display: block;
   flex: 1 1 auto;
   position: relative;

--- a/src/components/DocsWrapper.tsx
+++ b/src/components/DocsWrapper.tsx
@@ -1,4 +1,4 @@
-import styled from '../utils/styled';
+import styled from 'utils/styled';
 
 const DocsWrapper = styled('article')`
   display: block;

--- a/src/components/DocsWrapper.tsx
+++ b/src/components/DocsWrapper.tsx
@@ -1,0 +1,11 @@
+import styled from '../utils/styled';
+
+const DocsWrapper = styled('div')`
+  display: block;
+  flex: 1 1 auto;
+  position: relative;
+  padding: ${props => props.theme.dimensions.containerPadding}rem;
+  padding-bottom: 3rem;
+`;
+
+export default DocsWrapper;

--- a/src/components/LayoutMain.tsx
+++ b/src/components/LayoutMain.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from '../utils/styled';
+import styled from 'utils/styled';
 
 const StyledLayoutMain = styled('main')`
   display: flex;

--- a/src/components/LayoutRoot.tsx
+++ b/src/components/LayoutRoot.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import styled from '../utils/styled';
 
-import 'normalize.css';
-import '../styles/normalize';
-import 'prism-themes/themes/prism-a11y-dark.css';
-
 const StyledLayoutRoot = styled('div')`
   display: flex;
   flex-direction: column;

--- a/src/components/LayoutRoot.tsx
+++ b/src/components/LayoutRoot.tsx
@@ -10,7 +10,7 @@ const StyledLayoutRoot = styled('div')`
   flex-direction: column;
   min-height: 100vh;
 
-  @media (min-width: ${props => props.theme.breakpoints.sm}px) {
+  @media (min-width: ${props => props.theme.breakpoints.md}px) {
     flex-direction: row;
   }
 `;

--- a/src/components/LayoutRoot.tsx
+++ b/src/components/LayoutRoot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from '../utils/styled';
+import styled from 'utils/styled';
 
 const StyledLayoutRoot = styled('div')`
   display: flex;

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import styled from '../utils/styled';
+
+import { media } from '../styles/mixins';
+
+interface MarkdownContentProps {
+  className?: string;
+  html: string;
+}
+
+const MarkdownContent: React.SFC<MarkdownContentProps> = ({ className, html }) => (
+  <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
+);
+
+export default styled(MarkdownContent)`
+  li + li {
+    margin-top: 0.25rem;
+  }
+
+  .gatsby-highlight {
+    margin: 1rem 0;
+
+    code,
+    pre {
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  }
+
+  a[href^='#fn-'],
+  a[href^='#fnref-'] {
+    display: inline-block;
+    margin-left: 0.1rem;
+    font-weight: bold;
+  }
+
+  .footnotes {
+    margin-top: 2rem;
+    font-size: 85%;
+    li[id^='fn-'] {
+      p {
+        // Remark for some reason puts the footnote reflink *after* the 'p' tag.
+        display: inline;
+      }
+    }
+  }
+
+  .lead {
+    font-size: 1.25rem;
+    font-weight: 300;
+
+    @media (min-width: ${props => props.theme.breakpoints.md}) {
+      font-size: 1.5rem;
+    }
+  }
+`;

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styled from '../utils/styled';
+import styled from 'utils/styled';
 
 interface MarkdownContentProps {
   className?: string;

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
 import styled from '../utils/styled';
 
-import { media } from '../styles/mixins';
-
 interface MarkdownContentProps {
   className?: string;
   html: string;
 }
 
 const MarkdownContent: React.SFC<MarkdownContentProps> = ({ className, html }) => (
-  <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
+  <section className={className} dangerouslySetInnerHTML={{ __html: html }} />
 );
 
 export default styled(MarkdownContent)`

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -14,20 +14,20 @@ const Wrapper = styled('header')`
   background-color: ${props => props.theme.colors.drawer.background};
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
-  @media (min-width: ${props => props.theme.breakpoints.sm}px) {
+  @media (min-width: ${props => props.theme.breakpoints.md}px) {
     flex: 0 0 ${props => props.theme.widths.drawer.sm}px;
     box-shadow: none;
     border-bottom: none;
     border-right: 1px solid ${props => props.theme.colors.drawer.border};
   }
 
-  @media (min-width: ${props => props.theme.breakpoints.md}px) {
+  @media (min-width: ${props => props.theme.breakpoints.lg}px) {
     flex: 0 0 ${props => props.theme.widths.drawer.lg}px;
   }
 `;
 
 const WrapperInner = styled('div')`
-  @media (min-width: ${props => props.theme.breakpoints.sm}px) {
+  @media (min-width: ${props => props.theme.breakpoints.md}px) {
     position: fixed;
     width: ${props => props.theme.widths.drawer.sm - 1}px;
     flex: 1 1 auto;
@@ -36,7 +36,7 @@ const WrapperInner = styled('div')`
     overflow-y: auto;
   }
 
-  @media (min-width: ${props => props.theme.breakpoints.md}px) {
+  @media (min-width: ${props => props.theme.breakpoints.lg}px) {
     width: ${props => props.theme.widths.drawer.lg - 1}px;
   }
 `;
@@ -68,7 +68,7 @@ const DocumentationNavMenus = styled<{ isOpen?: boolean }, 'div'>('div')``;
 const DocumentationNavMenusInner = styled<{ isOpen?: boolean }, 'div'>('div')`
   padding: ${props => props.theme.dimensions.containerPadding}rem;
 
-  @media (max-width: ${props => props.theme.breakpoints.sm - 1}px) {
+  @media (max-width: ${props => props.theme.breakpoints.md - 1}px) {
     position: fixed;
     top: 0px;
     left: 0px;
@@ -84,7 +84,7 @@ const DocumentationNavMenusInner = styled<{ isOpen?: boolean }, 'div'>('div')`
     opacity: ${props => (props.isOpen ? 1 : 0)};
   }
 
-  @media (min-width: ${props => props.theme.breakpoints.sm}px) {
+  @media (min-width: ${props => props.theme.breakpoints.md}px) {
     opacity: 1 !important;
     padding-top: 0;
     padding-bottom: 3rem;
@@ -104,7 +104,7 @@ const FloatingNavButtonWrapper = styled('div')`
   border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 2px 4px 1px rgba(0, 0, 0, 0.15);
 
-  @media (min-width: ${props => props.theme.breakpoints.sm}px) {
+  @media (min-width: ${props => props.theme.breakpoints.md}px) {
     display: none;
   }
 `;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -156,12 +156,12 @@ class Header extends React.Component<HeaderProps, HeaderState> {
                   Index
                 </Link>
                 {navigation &&
-                  navigation.map(({ node }, i) => (
-                    <div key={i}>
-                      {node.category}
+                  navigation.map(({ node }) => (
+                    <div key={node.title}>
+                      {node.title}
                       <ul>
-                        {node.items.map((item, y) => (
-                          <li key={y}>
+                        {node.items.map(item => (
+                          <li key={item.id}>
                             <Link to={item.slug} onClick={this.closeNavMenu}>
                               {item.title}
                             </Link>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import Link from 'gatsby-link';
 
-import styled from '../utils/styled';
+import styled from 'utils/styled';
 import Container from './Container';
-import { MenuNode } from '../interfaces/nodes';
-import { brandColors } from '../styles/theme';
+import { MenuNode } from 'interfaces/nodes';
+import { brandColors } from 'styles/theme';
 
 const Wrapper = styled('header')`
   display: flex;

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from '../utils/styled';
+import styled, { css } from 'utils/styled';
 
 interface PageProps {
   docsPage?: boolean;

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,19 +1,22 @@
-import * as React from 'react';
-import styled from '../utils/styled';
+import styled, { css } from '../utils/styled';
 
-const StyledPage = styled('div')`
+interface PageProps {
+  docsPage?: boolean;
+}
+
+const Page = styled<PageProps, 'div'>('div')`
   display: block;
   flex: 1 1 auto;
   position: relative;
-  padding: 0;
+  ${props =>
+    props.docsPage
+      ? css`
+          padding: 0;
+        `
+      : css`
+          padding: ${props.theme.dimensions.containerPadding}rem;
+          padding-bottom: 3rem;
+        `};
 `;
-
-interface PageProps {
-  className?: string;
-}
-
-const Page: React.SFC<PageProps> = ({ children, className }) => (
-  <StyledPage className={className}>{children}</StyledPage>
-);
 
 export default Page;

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -5,8 +5,7 @@ const StyledPage = styled('div')`
   display: block;
   flex: 1 1 auto;
   position: relative;
-  padding: ${props => props.theme.dimensions.containerPadding}rem;
-  padding-bottom: 3rem;
+  padding: 0;
 `;
 
 interface PageProps {

--- a/src/interfaces/nodes.ts
+++ b/src/interfaces/nodes.ts
@@ -5,7 +5,6 @@ export interface MenuItem {
 }
 
 export interface MenuNode {
-  id: string;
-  category: string;
+  title: string;
   items: MenuItem[];
 }

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -8,6 +8,10 @@ import theme from '../styles/theme';
 import { ThemeProvider } from '../utils/styled';
 import { MenuNode } from '../interfaces/nodes';
 
+import 'normalize.css';
+import '../styles/normalize';
+import 'prism-themes/themes/prism-a11y-dark.css';
+
 interface WrapperProps {
   children: () => any;
   data: {

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
 
-import Navigation from '../components/Navigation';
-import LayoutRoot from '../components/LayoutRoot';
-import LayoutMain from '../components/LayoutMain';
-import theme from '../styles/theme';
-import { ThemeProvider } from '../utils/styled';
-import { MenuNode } from '../interfaces/nodes';
+import Navigation from 'components/Navigation';
+import LayoutRoot from 'components/LayoutRoot';
+import LayoutMain from 'components/LayoutMain';
+import theme from 'styles/theme';
+import { ThemeProvider } from 'utils/styled';
+import { MenuNode } from 'interfaces/nodes';
 
 import 'normalize.css';
-import '../styles/normalize';
+import 'styles/normalize';
 import 'prism-themes/themes/prism-a11y-dark.css';
 
 interface WrapperProps {

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -54,8 +54,7 @@ export const query = graphql`
     navigationMenus: allTocJson {
       edges {
         node {
-          id
-          category
+          title
           items {
             id
             slug

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Link from 'gatsby-link';
 
-import Page from '../components/Page';
-import Container from '../components/Container';
+import Page from 'components/Page';
+import Container from 'components/Container';
 
 const NotFoundPage = () => (
   <Page>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Link from 'gatsby-link';
 
-import Page from '../components/Page';
-import Container from '../components/Container';
+import Page from 'components/Page';
+import Container from 'components/Container';
 
 const IndexPage = () => (
   <Page>

--- a/src/pages/page-2.tsx
+++ b/src/pages/page-2.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Link from 'gatsby-link';
 
-import Page from '../components/Page';
-import Container from '../components/Container';
+import Page from 'components/Page';
+import Container from 'components/Container';
 
 export default () => (
   <Page>

--- a/src/styles/mixins.ts
+++ b/src/styles/mixins.ts
@@ -1,4 +1,4 @@
-import { css } from '../utils/styled';
+import { css } from 'utils/styled';
 import theme from './theme';
 
 export const getEmSize = (size: number) => size / theme.dimensions.fontSize.regular;

--- a/src/styles/normalize.ts
+++ b/src/styles/normalize.ts
@@ -1,4 +1,4 @@
-import { injectGlobal } from '../utils/styled';
+import { injectGlobal } from 'utils/styled';
 import { onEvent, media } from './mixins';
 
 import theme from './theme';

--- a/src/styles/normalize.ts
+++ b/src/styles/normalize.ts
@@ -138,7 +138,7 @@ injectGlobal`
   }
 
   strong {
-    color: $color-heading;
+    color: ${theme.colors.ink}};
   }
 
   ul,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -61,9 +61,9 @@ const theme: Theme = {
   fonts: {
     sansSerif:
       // tslint:disable-next-line:max-line-length
-      '-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif',
-    serif: 'Georgia, "Times New Roman", Times, serif',
-    monospace: 'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace, monospace'
+      '-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, Arial, sans-serif',
+    serif: 'Georgia, Times New Roman, Times, serif',
+    monospace: 'Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace, monospace'
   },
 
   // Media breakpoints (Important: use `min-width`!)

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,4 +1,4 @@
-import { Theme } from '../utils/styled';
+import { Theme } from 'utils/styled';
 
 export const brandColors = {
   katablue: '#2a90ff',

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
+import Link from 'gatsby-link';
 
 import Page from '../components/Page';
 import Container from '../components/Container';
+import getPageById from '../utils/getPageById';
+import { MenuNode } from '../interfaces/nodes';
 
 interface PageTemplateProps {
   data: {
@@ -15,24 +18,51 @@ interface PageTemplateProps {
         };
       };
     };
+    sectionList: {
+      edges: Array<{
+        node: MenuNode;
+      }>;
+    };
     markdownRemark: {
       html: string;
       excerpt: string;
       frontmatter: {
+        id: string;
         title: string;
+        prev?: string;
+        next?: string;
       };
     };
   };
 }
 
-const PageTemplate: React.SFC<PageTemplateProps> = ({ data }) => (
-  <Page>
-    <Container>
-      <h1>{data.markdownRemark.frontmatter.title}</h1>
-      <div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
-    </Container>
-  </Page>
-);
+const PageTemplate: React.SFC<PageTemplateProps> = ({ data }) => {
+  const { markdownRemark, sectionList } = data;
+  const { prev, next } = markdownRemark.frontmatter;
+  const prevPage = getPageById(sectionList.edges, prev);
+  const nextPage = getPageById(sectionList.edges, next);
+
+  return (
+    <Page>
+      <Container>
+        <h1>{markdownRemark.frontmatter.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: markdownRemark.html }} />
+        <section>
+          {prevPage && (
+            <>
+              Previous Page: <Link to={prevPage.slug}>{prevPage.title}</Link>
+            </>
+          )}
+          {nextPage && (
+            <>
+              Next Page: <Link to={nextPage.slug}>{nextPage.title}</Link>
+            </>
+          )}
+        </section>
+      </Container>
+    </Page>
+  );
+};
 
 export default PageTemplate;
 
@@ -48,11 +78,26 @@ export const query = graphql`
         }
       }
     }
+    sectionList: allTocJson {
+      edges {
+        node {
+          title
+          items {
+            id
+            slug
+            title
+          }
+        }
+      }
+    }
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
       excerpt
       frontmatter {
+        id
         title
+        prev
+        next
       }
     }
   }

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import Link from 'gatsby-link';
 
-import Page from '../components/Page';
-import Container from '../components/Container';
-import getPageById from '../utils/getPageById';
-import { MenuNode } from '../interfaces/nodes';
-import MarkdownContent from '../components/MarkdownContent';
-import DocsWrapper from '../components/DocsWrapper';
-import DocsHeader from '../components/DocsHeader';
+import Page from 'components/Page';
+import Container from 'components/Container';
+import getPageById from 'utils/getPageById';
+import { MenuNode } from 'interfaces/nodes';
+import MarkdownContent from 'components/MarkdownContent';
+import DocsWrapper from 'components/DocsWrapper';
+import DocsHeader from 'components/DocsHeader';
 
 interface PageTemplateProps {
   data: {

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -5,6 +5,8 @@ import Page from '../components/Page';
 import Container from '../components/Container';
 import getPageById from '../utils/getPageById';
 import { MenuNode } from '../interfaces/nodes';
+import MarkdownContent from '../components/MarkdownContent';
+import DocsWrapper from '../components/DocsWrapper';
 
 interface PageTemplateProps {
   data: {
@@ -44,22 +46,24 @@ const PageTemplate: React.SFC<PageTemplateProps> = ({ data }) => {
 
   return (
     <Page>
-      <Container>
-        <h1>{markdownRemark.frontmatter.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: markdownRemark.html }} />
-        <section>
-          {prevPage && (
-            <>
-              Previous Page: <Link to={prevPage.slug}>{prevPage.title}</Link>
-            </>
-          )}
-          {nextPage && (
-            <>
-              Next Page: <Link to={nextPage.slug}>{nextPage.title}</Link>
-            </>
-          )}
-        </section>
-      </Container>
+      <DocsWrapper>
+        <Container>
+          <h1>{markdownRemark.frontmatter.title}</h1>
+          <MarkdownContent html={markdownRemark.html} />
+        </Container>
+      </DocsWrapper>
+      <section>
+        {prevPage && (
+          <>
+            Previous Page: <Link to={prevPage.slug}>{prevPage.title}</Link>
+          </>
+        )}
+        {nextPage && (
+          <>
+            Next Page: <Link to={nextPage.slug}>{nextPage.title}</Link>
+          </>
+        )}
+      </section>
     </Page>
   );
 };

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -7,6 +7,7 @@ import getPageById from '../utils/getPageById';
 import { MenuNode } from '../interfaces/nodes';
 import MarkdownContent from '../components/MarkdownContent';
 import DocsWrapper from '../components/DocsWrapper';
+import DocsHeader from '../components/DocsHeader';
 
 interface PageTemplateProps {
   data: {
@@ -45,14 +46,16 @@ const PageTemplate: React.SFC<PageTemplateProps> = ({ data }) => {
   const nextPage = getPageById(sectionList.edges, next);
 
   return (
-    <Page>
+    <Page docsPage>
       <DocsWrapper>
         <Container>
-          <h1>{markdownRemark.frontmatter.title}</h1>
+          <DocsHeader>
+            <h1>{markdownRemark.frontmatter.title}</h1>
+          </DocsHeader>
           <MarkdownContent html={markdownRemark.html} />
         </Container>
       </DocsWrapper>
-      <section>
+      <aside>
         {prevPage && (
           <>
             Previous Page: <Link to={prevPage.slug}>{prevPage.title}</Link>
@@ -63,7 +66,7 @@ const PageTemplate: React.SFC<PageTemplateProps> = ({ data }) => {
             Next Page: <Link to={nextPage.slug}>{nextPage.title}</Link>
           </>
         )}
-      </section>
+      </aside>
     </Page>
   );
 };

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -16,3 +16,10 @@ declare module '*.module.css' {
   const cssModule: CSSModule;
   export = cssModule;
 }
+
+// file types
+
+declare module '*.json' {
+  const name: any;
+  export = name;
+}

--- a/src/utils/getEmSize.ts
+++ b/src/utils/getEmSize.ts
@@ -1,4 +1,4 @@
-import theme from '../styles/theme';
+import theme from 'styles/theme';
 
 const getEmSize = (size: number) => size / theme.dimensions.fontSize.regular;
 

--- a/src/utils/getPageById.ts
+++ b/src/utils/getPageById.ts
@@ -1,0 +1,14 @@
+import { MenuNode, MenuItem } from '../interfaces/nodes';
+
+const getPageById = (sectionList: Array<{ node: MenuNode }>, templateFile?: string) => {
+  if (!templateFile) {
+    return null;
+  }
+
+  const sectionItems = sectionList.map(({ node }) => node.items);
+  const flattenedSectionItems: MenuItem[] = [].concat.apply([], sectionItems);
+
+  return flattenedSectionItems.find(item => item.id === templateFile);
+};
+
+export default getPageById;

--- a/src/utils/getPageById.ts
+++ b/src/utils/getPageById.ts
@@ -1,4 +1,4 @@
-import { MenuNode, MenuItem } from '../interfaces/nodes';
+import { MenuNode, MenuItem } from 'interfaces/nodes';
 
 const getPageById = (sectionList: Array<{ node: MenuNode }>, templateFile?: string) => {
   if (!templateFile) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     "jsx": "react",
     "lib": ["dom", "es2015", "es2017"],
+    "baseUrl": "./src/",
     "outDir": "./dist/",
     "sourceMap": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3903,6 +3903,10 @@ gatsby-plugin-react-next@^1.0.11:
     react "^16.0.0"
     react-dom "^16.0.0"
 
+gatsby-plugin-resolve-src@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-resolve-src/-/gatsby-plugin-resolve-src-1.1.3.tgz#271b47808f351cad8911be5c7d890f0b328537d8"
+
 gatsby-plugin-sharp@^1.6.44:
   version "1.6.44"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-1.6.44.tgz#397e53e2962e5e1dc870408610aad7d6d2d64cb8"


### PR DESCRIPTION
Similar behaviour to the ReactJS docs.

Paginations are generated by creating a `prev` and/or `next` frontmatter in the Markdown containing the page id of the next page. If no previous/next page exists, feel free to remove said frontmatter.

![image](https://user-images.githubusercontent.com/5663877/40266995-6b8f48a2-5b7f-11e8-97a7-0672bfb644a0.png)

Then it will generate a pagination at the bottom.

![ezgif-4-65416ae29f](https://user-images.githubusercontent.com/5663877/40266976-4b8758b0-5b7f-11e8-9cfb-5e0706cf8e67.gif)

